### PR TITLE
FIX: mechanic crash

### DIFF
--- a/gamedata/scripts/igi_task_manager.script
+++ b/gamedata/scripts/igi_task_manager.script
@@ -428,6 +428,22 @@ function axr_task_manager.get_task_job_description( task_id )
 	return old_get_task_job_description(task_id)
 end
 
+old_trigger_fetch_func = axr_task_manager.trigger_fetch_func
+function axr_task_manager.trigger_fetch_func( task_id )
+	local CACHE = igi_generic_task.TASK_SETUP[task_id]
+	if CACHE then return end
+
+	return old_trigger_fetch_func(task_id)
+end
+
+old_trigger_job_func = axr_task_manager.trigger_job_func
+function axr_task_manager.trigger_job_func( task_id )
+	local CACHE = igi_generic_task.TASK_SETUP[task_id]
+	if CACHE then return end
+
+	return old_trigger_job_func(task_id)
+end
+
 old_text_npc_has_task = dialogs.text_npc_has_task
 function dialogs.text_npc_has_task(a,b)
 	local npc = dialogs.who_is_npc(a, b)


### PR DESCRIPTION
This should fix the following crash:
```
axr_task_manager.script:1105: attempt to index a nil value
```

The edits follow the same pattern as the existing monkey patches by circumventing the functions if the `task_id` exists within `igi_generic_task.TASK_SETUP`.